### PR TITLE
75 enhancement change the consoleid bassed on loaded book

### DIFF
--- a/src/Assets/Fighting Fantasy Books/FF01_The_Warlock_of_Firetop_Mountain.json
+++ b/src/Assets/Fighting Fantasy Books/FF01_The_Warlock_of_Firetop_Mountain.json
@@ -6,6 +6,7 @@
     "publisher": "Puffin Books",
     "publisher_info": "Puffin Books, Penguin Books Ltd, Harmondsworth, Middlesex, England Viking Penguin Inc., 40 West 23rd Street, New York, New York 10010. U.S.A. Penguin Books Australia Ltd, Ringwood, Victoria, Australia Penguin Books Canada Limited, 2801 John Street, Markham, Ontario, Canada L3R 1B4 Penguin Books (N.Z.) Ltd, 182-190 Wairau Road, Auckland 10, New Zealand First published 1982 Reprinted 1982 (five times), 1983 (thirteen times), 1984 (seven times). 1985 (twice) Copyright © Steve Jackson and Ian Livingstone, 1982 Illustrations copyright Russ Nicholson, 1982 All rights reserved Made and printed in Great Britain by Richard Clay (The Chaucer Press) Ltd. Bungay, Suffolk Set in VIP Palatino",
     "dedication": "Dedicated to Joanna Ashton, a true Galadriel of the spirit... and to Anne and Neville, the real wizards.",
+    "tag": "FF01",
 
     "text_array": [
       true,

--- a/src/Scripts/playerInputFunctions.js
+++ b/src/Scripts/playerInputFunctions.js
@@ -268,7 +268,8 @@ async function saveGame() {
     gameText: document.getElementById("gameText").innerHTML,
     notesBoxTextArea: document.getElementById("notesBoxTextArea").value,
     'inputLog': inputLog,
-    'inputLogIndex': inputLogIndex
+    'inputLogIndex': inputLogIndex,
+    'consoleIDTag': document.getElementById("consoleIDTag").textContent
   };
   //Save book style if it is present
   if (document.getElementById("bookStyle")) {
@@ -311,6 +312,7 @@ async function loadGame() {
     }
     if (saveGame["inputLog"]) {inputLog = saveGame['inputLog']};
     if (saveGame["inputLogIndex"]) {inputLog = saveGame['inputLogIndex']};
+    if (saveGame["consoleIDTag"]) {document.getElementById("consoleIDTag").textContent = saveGame['consoleIDTag']};
     
     //Update console
     renderConsoleEntry([true, "load"], false, true);

--- a/src/Scripts/roomReader.js
+++ b/src/Scripts/roomReader.js
@@ -60,6 +60,11 @@ function onBookLoad(bookString) {
           // console.log(data[i].css);
           cssString = data[i].css.toString();
         }
+        if (data[i].hasOwnProperty('tag')) {
+          document.getElementById('consoleIDTag').textContent = data[i].tag;
+        } else {
+          document.getElementById('consoleIDTag').textContent = "home";
+        }
       }
     }
     if (cssString == "") {

--- a/src/index.html
+++ b/src/index.html
@@ -46,7 +46,7 @@ An excellent place to keep notes while you play, does not save between sessions 
 
         <div id="inputBox" class="consoleEntry">
           <!-- Display Text -->
-          <span id="consoleID">[home ~/]></span>
+          <span id="consoleID">[<span id="consoleIDTag">home</span> ~/]></span>
           <!-- Input Box -->
           <input
             type="text"


### PR DESCRIPTION
If a book as a `tag` element in its meta page, it will update the console to reflect that to help indicate which book is currently loaded. This is also tracked by the save game function